### PR TITLE
Disable asusdec driver logging

### DIFF
--- a/drivers/input/asusec/asusdec.c
+++ b/drivers/input/asusec/asusdec.c
@@ -147,7 +147,7 @@ void ec_irq_disable(void)
 {
 	unsigned long irqflags;
 	spin_lock_irqsave(&ec_chip->irq_lock, irqflags);
-	printk("ec_irq_disable flag = %d\n", ec_chip->apwake_disabled);
+	ASUSDEC_INFO("ec_irq_disable flag = %d\n", ec_chip->apwake_disabled);
 	if (!ec_chip->apwake_disabled)
 	{
 		ec_chip->apwake_disabled = 1;
@@ -162,7 +162,7 @@ void ec_irq_enable(void)
 {
 	unsigned long irqflags;
 	spin_lock_irqsave(&ec_chip->irq_lock, irqflags);
-	printk("ec_irq_enable flag = %d\n", ec_chip->apwake_disabled);
+	ASUSDEC_INFO("ec_irq_enable flag = %d\n", ec_chip->apwake_disabled);
 	if (ec_chip->apwake_disabled) 
 	{
 		enable_irq(gpio_to_irq(asusdec_apwake_gpio));
@@ -849,10 +849,10 @@ static irqreturn_t asusdec_interrupt_handler(int irq, void *dev_id){
 		printk("==Receive the dock in irq==\n");
 	}
 	else if (irq == asusdec_apwake_gpio_irq){
-		ASUSDEC_NOTICE("asusdec_apwake_gpio_irq before call irq disable\n");
+		ASUSDEC_INFO("asusdec_apwake_gpio_irq before call irq disable\n");
 		ec_irq_disable();
-		ASUSDEC_NOTICE("asusdec_apwake_gpio_irq after call irq disable\n");
-		ASUSDEC_NOTICE("print value gpio=%d irq=%d ec_chip->op_mode=%d\n",gpio ,irq ,ec_chip->op_mode);
+		ASUSDEC_INFO("asusdec_apwake_gpio_irq after call irq disable\n");
+		ASUSDEC_INFO("print value gpio=%d irq=%d ec_chip->op_mode=%d\n",gpio ,irq ,ec_chip->op_mode);
 		if (ec_chip->op_mode == 1){
 			ASUSDEC_NOTICE("into asusdec_fw_update_work");
 			schedule_work(&ec_chip->asusdec_fw_update_work);
@@ -1198,12 +1198,12 @@ static void asusdec_kb_report_work_function(struct work_struct *dat)
                 return;
         }
 
-        ASUSDEC_NOTICE("key code[1] : 0x%x\n",ec_chip->i2c_kb_data[0]);
-        ASUSDEC_NOTICE("key code[2] : 0x%x\n",ec_chip->i2c_kb_data[1]);
-        ASUSDEC_NOTICE("key code[3] : 0x%x\n",ec_chip->i2c_kb_data[2]);
-        ASUSDEC_NOTICE("key code[4] : 0x%x\n",ec_chip->i2c_kb_data[3]);
-        ASUSDEC_NOTICE("key code[5] : 0x%x\n",ec_chip->i2c_kb_data[4]);
-        ASUSDEC_NOTICE("key code[6] : 0x%x\n",ec_chip->i2c_kb_data[5]);
+        ASUSDEC_INFO("key code[1] : 0x%x\n",ec_chip->i2c_kb_data[0]);
+        ASUSDEC_INFO("key code[2] : 0x%x\n",ec_chip->i2c_kb_data[1]);
+        ASUSDEC_INFO("key code[3] : 0x%x\n",ec_chip->i2c_kb_data[2]);
+        ASUSDEC_INFO("key code[4] : 0x%x\n",ec_chip->i2c_kb_data[3]);
+        ASUSDEC_INFO("key code[5] : 0x%x\n",ec_chip->i2c_kb_data[4]);
+        ASUSDEC_INFO("key code[6] : 0x%x\n",ec_chip->i2c_kb_data[5]);
 	
         ec_chip->keypad_data.extend = 0;
 		/*
@@ -1216,7 +1216,7 @@ static void asusdec_kb_report_work_function(struct work_struct *dat)
 	if( (ec_chip->i2c_kb_data[0] == 0x5 && ec_chip->i2c_kb_data[2] == 0x13) ||
 	    (ec_chip->i2c_kb_data[0] == 0x4 && ec_chip->i2c_kb_data[2] == 0x14) )
 	{
-		ASUSDEC_NOTICE("consumer key\n");
+		ASUSDEC_INFO("consumer key\n");
 		if(ec_chip->i2c_kb_data[3])
 			input_report_key(ec_chip->indev, asusdec_kp_consumer_key_mapping(ec_chip->i2c_kb_data[3]), 1);
 		else
@@ -1886,7 +1886,7 @@ static void asusdec_work_function(struct work_struct *dat)
 	int irq = gpio_to_irq(gpio);
 	int ret_val = 0;
 	ret_val = asusdec_intr_i2c_read_data(&intr_client);
-	ASUSDEC_NOTICE("=======0x%x 0x%x 0x%x 0x%x=======ap_wake =%d\n", ec_chip->intr_i2c_data[0],
+	ASUSDEC_INFO("=======0x%x 0x%x 0x%x 0x%x=======ap_wake =%d\n", ec_chip->intr_i2c_data[0],
                  ec_chip->intr_i2c_data[1], ec_chip->intr_i2c_data[2], ec_chip->intr_i2c_data[3], gpio_get_value(asusdec_apwake_gpio));
 	if (ret_val < 0){
 		printk("asusdec_work_function ret_val < 0!!\n");

--- a/drivers/input/asusec/asusdec.h
+++ b/drivers/input/asusec/asusdec.h
@@ -8,6 +8,15 @@
 /*
  * compiler option
  */
+/*
+ * ASUSDEC_DEBUG: Controls verbose debugging output
+ * 0 = Minimal logging (recommended for normal use to reduce log clutter)
+ * 1 = Verbose logging (useful for debugging hardware issues)
+ * 
+ * Note: When set to 0, ASUSDEC_INFO() calls become no-ops, significantly
+ * reducing the amount of logging during normal operation, especially
+ * during frequent hardware interactions like touchpad/keyboard events.
+ */
 #define ASUSDEC_DEBUG			0
 #define FACTORY_MODE                    0
 #define TF600T_TOUCHPAD_MODE	0	// 0: relative mode, 1: absolute mode


### PR DESCRIPTION
Reduce kernel log clutter from asusdec driver by disabling verbose logging.

Previously, frequent hardware interactions generated excessive `printk` and `ASUSDEC_NOTICE` messages (e.g., `asusdec_work_function`, `ec_irq_enable/disable`, `asusdec_interrupt_handler`, keyboard events). This PR converts these verbose calls to `ASUSDEC_INFO`, which are suppressed when `ASUSDEC_DEBUG` is 0, significantly reducing log spam while preserving critical error and notice messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3c6a63b-148e-4d33-9fbb-55f0b2adb7ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d3c6a63b-148e-4d33-9fbb-55f0b2adb7ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

